### PR TITLE
Identify bndbox coordinates by tag

### DIFF
--- a/xml_to_csv.py
+++ b/xml_to_csv.py
@@ -9,17 +9,27 @@ def xml_to_csv(path):
     for xml_file in glob.glob(path + '/*.xml'):
         tree = ET.parse(xml_file)
         root = tree.getroot()
+        
         for member in root.findall('object'):
-            value = (root.find('filename').text,
-                     int(root.find('size')[0].text),
-                     int(root.find('size')[1].text),
-                     member[0].text,
-                     int(member[4][0].text),
-                     int(member[4][1].text),
-                     int(member[4][2].text),
-                     int(member[4][3].text)
-                     )
-            xml_list.append(value)
+
+                ymin, xmin, ymax, xmax = None, None, None, None
+
+                for boxes in member.findall("bndbox"):
+                    ymin = int(boxes.find("ymin").text)
+                    xmin = int(boxes.find("xmin").text)
+                    ymax = int(boxes.find("ymax").text)
+                    xmax = int(boxes.find("xmax").text)
+
+                value = (root.find('filename').text,
+                         int(root.find('size')[0].text),
+                         int(root.find('size')[1].text),
+                         member[0].text,
+                         xmin,
+                         ymin,
+                         xmax,
+                         ymax)
+                xml_list.append(value)
+                
     column_name = ['filename', 'width', 'height', 'class', 'xmin', 'ymin', 'xmax', 'ymax']
     xml_df = pd.DataFrame(xml_list, columns=column_name)
     return xml_df


### PR DESCRIPTION
Made s small change in xml_to_csv.py
Use the XML tags to identify "ymin, xmin, ymax, xmax", and not only by position.

I made this, because I ran in some trouble. Had XML files with another order of the box coordinates.
