### PR TITLE
Convert files without any bounding boxes

### DIFF
--- a/xml_to_csv.py
+++ b/xml_to_csv.py
@@ -20,6 +20,15 @@ def xml_to_csv(path):
                      int(member[4][3].text)
                      )
             xml_list.append(value)
+            
+        # create a registry for the image even if there's no 'object' annotated:
+        #if not root.findall('object'):
+        #    value = (root.find('filename').text,
+        #             int(root.find('size')[0].text),
+        #             int(root.find('size')[1].text)
+        #            )
+        #    xml_list.append(value)
+    
     column_name = ['filename', 'width', 'height', 'class', 'xmin', 'ymin', 'xmax', 'ymax']
     xml_df = pd.DataFrame(xml_list, columns=column_name)
     return xml_df


### PR DESCRIPTION
Commented option to also convert "empty" .xml files that have no bounding boxes inside.
This will allow people to train background images (together with [this](https://github.com/tensorflow/models/issues/3578#issuecomment-375267920))